### PR TITLE
Allow to customize load trigger for lazy initialize

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,6 +266,11 @@ context.actions.add('app:start', [
 context.trigger('app:start');
 ```
 
+The InitializeLazy action has a getter `condition` that returns a promise. It
+allows customizing the load condition when executing the startup (lookup for
+matching elements) process. The default implementation waits for the DOM-ready
+state to be "complete" (using the `DOMContentLoaded` event to wait for).
+
 ##### Handling Errors
 
 Note that due to various reasons there could be an error during the

--- a/src/actions/InitializeLazy.js
+++ b/src/actions/InitializeLazy.js
@@ -27,6 +27,15 @@ export class InitializeLazy {
 		return null;
 	}
 
+	get condition() {
+		if (document.readyState === 'complete') {
+			return Promise.resolve();
+		}
+
+		return new Promise((resolve) =>
+			window.addEventListener('DOMContentLoaded', resolve, {once: true}));
+	}
+
 	get observerSettings() {
 		return {
 			rootMargin: '0px',
@@ -35,27 +44,35 @@ export class InitializeLazy {
 	}
 
 	run() {
-		const settings = __getSettings(this);
-		this._lookup(settings.selector);
+		const {selector} = __getSettings(this);
+		const { condition } = this;
+
+		if (!(condition instanceof Promise)) {
+			throw new Error('A conditon must be an instance of promise.')
+		}
+
+		condition
+			.then(() => this._lookup(selector))
+			.catch((error) => {
+				window.console &&
+				window.console.error &&
+				window.console.error('[InitializeLazy] ' + error.message);
+
+				this.context.trigger(this.event.type + ':error', {error});
+			});
 	}
 
 	_lookup(selector) {
-		const
-			{event} = this,
-			{data} = event,
-			root = data && data.root ? data.root : document.body,
-			elements = root.querySelectorAll(selector)
-		;
+		const {event} = this;
+		const {data} = event;
+		const root = data && data.root ? data.root : document.body;
+		const elements = root.querySelectorAll(selector);
 
 		if (elements.length === 0) {
 			return;
 		}
 
-		if (document.readyState === 'complete') {
-			this._setup(elements);
-		} else {
-			window.addEventListener('load', () => this._setup(elements), {once: true});
-		}
+		this._setup(elements);
 	}
 
 	_setup(elements) {

--- a/src/actions/InitializeLazy.js
+++ b/src/actions/InitializeLazy.js
@@ -12,6 +12,14 @@ function __getSettings(instance) {
 	return settings;
 }
 
+function __error(action, error) {
+	window.console &&
+	window.console.error &&
+	window.console.error('[InitializeLazy] ' + error.message);
+
+	action.context.trigger(action.event.type + ':error', {error});
+}
+
 
 export class InitializeLazy {
 
@@ -53,13 +61,7 @@ export class InitializeLazy {
 
 		condition
 			.then(() => this._lookup(selector))
-			.catch((error) => {
-				window.console &&
-				window.console.error &&
-				window.console.error('[InitializeLazy] ' + error.message);
-
-				this.context.trigger(this.event.type + ':error', {error});
-			});
+			.catch((error) => __error(this, error));
 	}
 
 	_lookup(selector) {
@@ -115,10 +117,7 @@ export class InitializeLazy {
 			// Execute the current action:
 			this._execute(Action);
 		})
-		.catch((error) => {
-			this.context.trigger(this.event.type + ':error', {error});
-			throw error;
-		});
+		.catch((error) => __error(this, error));
 	}
 
 	_execute(Action) {

--- a/src/actions/InitializeLazy.test.js
+++ b/src/actions/InitializeLazy.test.js
@@ -243,6 +243,9 @@ describe('The lazy initialize action', () => {
 	});
 
 	test('should log error when import action with incorrect module export', async () => {
+		const consoleError = global.console.error;
+		global.console.error = jest.fn();
+
 		const callback = jest.fn();
 		context.on(EVENT_NAME + ':error', callback);
 
@@ -253,15 +256,23 @@ describe('The lazy initialize action', () => {
 		intersect();
 		await flushPromises();
 
+		expect(global.console.error).toHaveBeenCalledTimes(1);
+		expect(global.console.error).toHaveBeenCalledWith('[InitializeLazy] Module must export Action or default');
+
 		expect(callback).toHaveBeenCalledTimes(1);
 		expect(callback).toHaveBeenCalledWith(expect.objectContaining({
 			data: {
 				error: new Error('Module must export Action or default'),
 			},
 		}));
+
+		global.console.error = consoleError;
 	});
 
 	test('should fail when import class with no run() method', async () => {
+		const consoleError = global.console.error;
+		global.console.error = jest.fn();
+
 		const callback = jest.fn();
 		context.on(EVENT_NAME + ':error', callback);
 
@@ -272,12 +283,17 @@ describe('The lazy initialize action', () => {
 		intersect();
 		await flushPromises();
 
+		expect(global.console.error).toHaveBeenCalledTimes(1);
+		expect(global.console.error).toHaveBeenCalledWith('[InitializeLazy] Module must be an Action');
+
 		expect(callback).toHaveBeenCalledTimes(1);
 		expect(callback).toHaveBeenCalledWith(expect.objectContaining({
 			data: {
 				error: new Error('Module must be an Action'),
 			},
 		}));
+
+		global.console.error = consoleError;
 	});
 
 	test('should import replace action in context with imported action', async () => {


### PR DESCRIPTION
This implements the feature request from #74.

Open ToDos:
* [x] Add tests for customized condition.